### PR TITLE
Add conversion from prosit-like models to msp spectral library format

### DIFF
--- a/aiproteomics/__init__.py
+++ b/aiproteomics/__init__.py
@@ -1,3 +1,1 @@
-# -*- coding: utf-8 -*-
-from . import frag
-from . import rt
+

--- a/aiproteomics/e2e/LICENSE
+++ b/aiproteomics/e2e/LICENSE
@@ -1,0 +1,204 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+
+

--- a/aiproteomics/e2e/README.md
+++ b/aiproteomics/e2e/README.md
@@ -1,0 +1,28 @@
+The code files in this directory are directly taken from (or modified from) that found in the prosit code base (found here: https://github.com/kusterlab/prosit/) and licensed under Apache License 2.0
+
+According to the zenodo citation at the time of adaptation, the following authors are credited with the original code:
+
+"creators": [
+        {
+            "affiliation": "Chair of Proteomics and Bioanalytics, Technical University of Munich, Germany",
+            "name": "Siegfried Gessulat",
+          "orcid": "0000-0001-5530-0674"
+        },
+        {
+            "affiliation": "Chair of Proteomics and Bioanalytics, Technical University of Munich, Germany",
+            "name": "Tobias Schmidt",
+          "orcid": "0000-0002-1883-6514"
+        },
+        {
+            "affiliation": "Chair of Proteomics and Bioanalytics, Technical University of Munich, Germany",
+            "name": "Mathias Wilhelm",
+          "orcid": "0000-0002-9224-3258"
+        },
+        {
+            "affiliation": "Chair of Proteomics and Bioanalytics, Technical University of Munich, Germany",
+            "name": "Bernhard Kuster",
+          "orcid": "0000-0002-9094-1677"
+        }
+]
+
+Note that since then parts of the code have been completely changed or new functions added.

--- a/aiproteomics/e2e/annotate.py
+++ b/aiproteomics/e2e/annotate.py
@@ -1,0 +1,46 @@
+# Code from (or adapted from) https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+import numpy
+import collections
+from aiproteomics.e2e.constants import AMINO_ACID, PROTON, ION_OFFSET, FORWARD, BACKWARD
+from aiproteomics.e2e import constants
+
+
+def adjust_masses(method):
+    if method == "SILAC":
+        offsets = {"K": 8.01419881319, "R": 10.008268599}
+    else:
+        raise ValueError("Don't know method: " + method)
+
+    for aa, offset in offsets.items():
+        AMINO_ACID[aa] += offset
+
+
+def get_mz(sum_, ion_offset, charge):
+    return (sum_ + ion_offset + charge * PROTON) / charge
+
+
+def get_mzs(cumsum, ion_type, z):
+    return [get_mz(s, ION_OFFSET[ion_type], z) for s in cumsum[:-1]]
+
+
+def get_annotation(forward, backward, charge, ion_types):
+    tmp = "{}{}"
+    tmp_nl = "{}{}-{}"
+    all_ = {}
+    for ion_type in ion_types:
+        if ion_type in constants.FORWARD:
+            cummass = forward
+        elif ion_type in constants.BACKWARD:
+            cummass = backward
+        else:
+            raise ValueError("unkown ion_type: {}".format(ion_type))
+        masses = get_mzs(cummass, ion_type, charge)
+        d = {tmp.format(ion_type, i + 1): m for i, m in enumerate(masses)}
+        all_.update(d)
+        for nl, offset in constants.NEUTRAL_LOSS.items():
+            nl_masses = get_mzs(cummass - offset, ion_type, charge)
+            d = {tmp_nl.format(ion_type, i + 1, nl): m for i, m in enumerate(nl_masses)}
+            all_.update(d)
+    return collections.OrderedDict(sorted(all_.items(), key=lambda t: t[0]))

--- a/aiproteomics/e2e/constants.py
+++ b/aiproteomics/e2e/constants.py
@@ -1,0 +1,96 @@
+# Code adapted from https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+ALPHABET = {
+    "A": 1,
+    "C": 2,
+    "D": 3,
+    "E": 4,
+    "F": 5,
+    "G": 6,
+    "H": 7,
+    "I": 8,
+    "K": 9,
+    "L": 10,
+    "M": 11,
+    "N": 12,
+    "P": 13,
+    "Q": 14,
+    "R": 15,
+    "S": 16,
+    "T": 17,
+    "V": 18,
+    "W": 19,
+    "Y": 20,
+    "M(ox)": 21,
+}
+ALPHABET_S = {integer: char for char, integer in ALPHABET.items()}
+
+CHARGES = [1, 2, 3, 4, 5, 6]
+DEFAULT_MAX_CHARGE = len(CHARGES)
+MAX_FRAG_CHARGE = 3
+MAX_SEQUENCE = 30
+MAX_ION = MAX_SEQUENCE - 1
+ION_TYPES = ["y", "b"]
+NLOSSES = ["", "H2O", "NH3"]
+
+FORWARD = {"a", "b", "c"}
+BACKWARD = {"x", "y", "z"}
+
+# Amino acids
+MODIFICATION = {
+    "CAM": 57.0214637236,  # Carbamidomethylation (CAM)
+    "OX": 15.99491,  # Oxidation
+}
+AMINO_ACID = {
+    "G": 57.021464,
+    "R": 156.101111,
+    "V": 99.068414,
+    "P": 97.052764,
+    "S": 87.032028,
+    "U": 150.95363,
+    "L": 113.084064,
+    "M": 131.040485,
+    "Q": 128.058578,
+    "N": 114.042927,
+    "Y": 163.063329,
+    "E": 129.042593,
+    "C": 103.009185 + MODIFICATION["CAM"],
+    "F": 147.068414,
+    "I": 113.084064,
+    "A": 71.037114,
+    "T": 101.047679,
+    "W": 186.079313,
+    "H": 137.058912,
+    "D": 115.026943,
+    "K": 128.094963,
+}
+AMINO_ACID["M(ox)"] = AMINO_ACID["M"] + MODIFICATION["OX"]
+
+# Atomic elements
+PROTON = 1.007276467
+ELECTRON = 0.00054858
+H = 1.007825035
+C = 12.0
+O = 15.99491463
+N = 14.003074
+
+# Tiny molecules
+N_TERMINUS = H
+C_TERMINUS = O + H
+CO = C + O
+CHO = C + H + O
+NH2 = N + H * 2
+H2O = H * 2 + O
+NH3 = N + H * 3
+
+NEUTRAL_LOSS = {"NH3": NH3, "H2O": H2O}
+
+ION_OFFSET = {
+    "a": N_TERMINUS - CHO,
+    "b": N_TERMINUS - H,
+    "c": N_TERMINUS + NH2,
+    "x": C_TERMINUS + CO - H,
+    "y": C_TERMINUS + H,
+    "z": C_TERMINUS - NH2,
+}

--- a/aiproteomics/e2e/convert_to_msp.py
+++ b/aiproteomics/e2e/convert_to_msp.py
@@ -1,0 +1,191 @@
+# Code from (or adapted from) https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+import numpy as np
+import pyteomics
+from pyteomics import mass
+
+from aiproteomics.e2e import constants
+from aiproteomics.e2e import utils
+
+
+def generate_aa_comp():
+    """
+    >>> aa_comp = generate_aa_comp()
+    >>> aa_comp["M"]
+    Composition({'H': 9, 'C': 5, 'S': 1, 'O': 1, 'N': 1})
+    >>> aa_comp["Z"]
+    Composition({'H': 9, 'C': 5, 'S': 1, 'O': 2, 'N': 1})
+    """
+
+    db = pyteomics.mass.mass.Unimod()
+    aa_comp = dict(pyteomics.mass.std_aa_comp)
+    s = db.by_title("Oxidation")["composition"]
+    aa_comp["Z"] = aa_comp["M"] + s
+    s = db.by_title("Carbamidomethyl")["composition"]
+    aa_comp["C"] = aa_comp["C"] + s
+    return aa_comp
+
+
+aa_comp = generate_aa_comp()
+
+
+def get_ions():
+    x = np.empty(
+        [constants.MAX_ION, len(constants.ION_TYPES), constants.MAX_FRAG_CHARGE],
+        dtype="|S6",
+    )
+    for fz in range(constants.MAX_FRAG_CHARGE):
+        for fty_i, fty in enumerate(constants.ION_TYPES):
+            for fi in range(constants.MAX_ION):
+                ion = fty + str(fi + 1)
+                if fz > 0:
+                    ion += "({}+)".format(fz + 1)
+                x[fi, fty_i, fz] = ion
+    x.flatten()
+    return x
+
+
+ox_int = constants.ALPHABET["M(ox)"]
+c_int = constants.ALPHABET["C"]
+
+
+def calculate_mods(sequence_integer):
+    """
+    >>> x = np.array([2, 15, 4, 3, 0, 0])
+    >>> calculate_mods(x)
+    1
+    >>> x = np.array([2, 15, 21, 3, 0, 0])
+    >>> calculate_mods(x)
+    2
+    """
+    return len(np.where((sequence_integer == ox_int) | (sequence_integer == c_int))[0])
+
+
+def generate_mods_string_tuples(sequence_integer):
+    list_mods = []
+    for mod in [ox_int, c_int]:
+        for position in np.where(sequence_integer == mod)[0]:
+            if mod == c_int:
+                list_mods.append((position, "C", "Carbamidomethyl"))
+            elif mod == ox_int:
+                list_mods.append((position, "M", "Oxidation"))
+            else:
+                raise ValueError("cant be true")
+    list_mods.sort(key=lambda tup: tup[0])  # inplace
+    return list_mods
+
+
+def generate_mod_strings(sequence_integer):
+    """
+    >>> x = np.array([1,2,3,1,2,21,0])
+    >>> y, z = generate_mod_strings(x)
+    >>> y
+    '3/1,C,Carbamidomethyl/4,C,Carbamidomethyl/5,M,Oxidation'
+    >>> z
+    'Carbamidomethyl@C2; Carbamidomethyl@C5; Oxidation@M6'
+    """
+    list_mods = generate_mods_string_tuples(sequence_integer)
+    if len(list_mods) == 0:
+        return "0", ""
+    else:
+        returnString_mods = ""
+        returnString_modString = ""
+        returnString_mods += str(len(list_mods))
+        for i, mod_tuple in enumerate(list_mods):
+            returnString_mods += (
+                "/" + str(mod_tuple[0]) + "," + mod_tuple[1] + "," + mod_tuple[2]
+            )
+            if i == 0:
+                returnString_modString += (
+                    mod_tuple[2] + "@" + mod_tuple[1] + str(mod_tuple[0] + 1)
+                )
+            else:
+                returnString_modString += (
+                    "; " + mod_tuple[2] + "@" + mod_tuple[1] + str(mod_tuple[0] + 1)
+                )
+
+    return returnString_mods, returnString_modString
+
+
+class Converter():
+    def __init__(self, data, out_path):
+        self.out_path = out_path
+        self.data = data
+
+    def convert(self):
+        IONS = get_ions().reshape(174, -1).flatten()
+        with open(self.out_path, mode="w", encoding="utf-8") as f:
+            first_spec = True
+            for i in range(self.data["iRT"].shape[0]):
+                aIntensity = self.data["intensities_pred"][i]
+                sel = np.where(aIntensity > 0)
+                aIntensity = aIntensity[sel]
+                collision_energy = self.data["collision_energy_aligned_normed"][i] * 100
+                iRT = self.data["iRT"][i]
+                aMass = self.data["masses_pred"][i][sel]
+                precursor_charge = self.data["precursor_charge_onehot"][i].argmax() + 1
+                sequence_integer = self.data["sequence_integer"][i]
+                aIons = IONS[sel]
+                spec = Spectrum(
+                    aIntensity,
+                    collision_energy,
+                    iRT,
+                    aMass,
+                    precursor_charge,
+                    sequence_integer,
+                    aIons,
+                )
+                if not first_spec:
+                    f.write("\n")
+                first_spec = False
+                f.write(str(spec))
+        return spec
+
+
+class Spectrum(object):
+    def __init__(
+        self,
+        aIntensity,
+        collision_energy,
+        iRT,
+        aMass,
+        precursor_charge,
+        sequence_integer,
+        aIons,
+    ):
+        self.aIntensity = aIntensity
+        self.collision_energy = collision_energy
+        self.iRT = iRT
+        self.aMass = aMass
+        self.precursor_charge = precursor_charge
+        self.aIons = aIons
+        self.mod, self.mod_string = generate_mod_strings(sequence_integer)
+        self.sequence = utils.get_sequence(sequence_integer)
+        # amino acid Z which is defined at the toplevel in generate_aa_comp
+        self.precursor_mass = pyteomics.mass.calculate_mass(
+            self.sequence.replace("M(ox)", "Z"),
+            aa_comp=aa_comp,
+            ion_type="M",
+            charge=int(self.precursor_charge),
+        )
+
+    def __str__(self):
+        s = "Name: {sequence}/{charge}\nMW: {precursor_mass}\n"
+        s += "Comment: Parent={precursor_mass} Collision_energy={collision_energy} "
+        s += "Mods={mod} ModString={sequence}//{mod_string}/{charge}"
+        s += "\nNum peaks: {num_peaks}"
+        num_peaks = len(self.aIntensity)
+        s = s.format(
+            sequence=self.sequence.replace("M(ox)", "M"),
+            charge=self.precursor_charge,
+            precursor_mass=self.precursor_mass,
+            collision_energy=np.round(self.collision_energy[0], 0),
+            mod=self.mod,
+            mod_string=self.mod_string,
+            num_peaks=num_peaks,
+        )
+        for mz, intensity, ion in zip(self.aMass, self.aIntensity, self.aIons):
+            s += "\n" + str(mz) + "\t" + str(intensity) + '\t"'
+            s += ion.decode("UTF-8").replace("(", "^").replace("+", "") + '/0.0ppm"'
+        return s

--- a/aiproteomics/e2e/match.py
+++ b/aiproteomics/e2e/match.py
@@ -1,0 +1,140 @@
+
+# Code from (or adapted from) https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+
+import numpy
+
+from aiproteomics.e2e import annotate
+from aiproteomics.e2e import constants
+
+
+def read_attribute(row, attribute):
+    if " " not in str(row[attribute]):
+        return []
+    else:
+        return [float(m) for m in row[attribute].split(" ")]
+
+
+def peptide_parser(p):
+    if p[0] == "(":
+        raise ValueError("sequence starts with '('")
+    n = len(p)
+    i = 0
+    while i < n:
+        if i < n - 3 and p[i + 1] == "(":
+            j = p[i + 2 :].index(")")
+            offset = i + j + 3
+            yield p[i:offset]
+            i = offset
+        else:
+            yield p[i]
+            i += 1
+
+
+def get_forward_backward(peptide):
+    amino_acids = peptide_parser(peptide)
+    masses = [constants.AMINO_ACID[a] for a in amino_acids]
+    forward = numpy.cumsum(masses)
+    backward = numpy.cumsum(list(reversed(masses)))
+    return forward, backward
+
+
+def get_tolerance(theoretical, mass_analyzer):
+    if mass_analyzer in constants.TOLERANCE:
+        tolerance, unit = constants.TOLERANCE[mass_analyzer]
+        if unit == "ppm":
+            return theoretical * float(tolerance) / 10 ** 6
+        elif unit == "da":
+            return float(tolerance)
+        else:
+            raise ValueError("unit {} not implemented".format(unit))
+    else:
+        raise ValueError("no tolerance implemented for {}".format(mass_analyzer))
+
+
+def is_in_tolerance(theoretical, observed, mass_analyzer):
+    mz_tolerance = get_tolerance(theoretical, mass_analyzer)
+    lower = observed - mz_tolerance
+    upper = observed + mz_tolerance
+    return theoretical >= lower and theoretical <= upper
+
+
+def binarysearch(masses_raw, theoretical, mass_analyzer):
+    lo, hi = 0, len(masses_raw) - 1
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        if is_in_tolerance(theoretical, masses_raw[mid], mass_analyzer):
+            return mid
+        elif masses_raw[mid] < theoretical:
+            lo = mid + 1
+        elif theoretical < masses_raw[mid]:
+            hi = mid - 1
+    return None
+
+
+def match(row, ion_types, max_charge=constants.DEFAULT_MAX_CHARGE):
+    masses_observed = read_attribute(row, "masses_raw")
+    intensities_observed = read_attribute(row, "intensities_raw")
+    forward_sum, backward_sum = get_forward_backward(row.modified_sequence[1:-1])
+    _max_charge = row.charge if row.charge <= max_charge else max_charge
+    matches = []
+    for charge_index in range(_max_charge):
+        d = {
+            "masses_raw": [],
+            "masses_theoretical": [],
+            "intensities_raw": [],
+            "matches": [],
+        }
+        charge = charge_index + 1
+        annotations = annotate.get_annotation(
+            forward_sum, backward_sum, charge, ion_types
+        )
+        for annotation, mass_t in annotations.items():
+            index = binarysearch(masses_observed, mass_t, row.mass_analyzer)
+            if index is not None:
+                d["masses_raw"].append(masses_observed[index])
+                d["intensities_raw"].append(intensities_observed[index])
+                d["masses_theoretical"].append(mass_t)
+                d["matches"].append(annotation)
+        matches.append(d)
+    return matches
+
+
+def c_lambda(matches, charge, attr):
+    def mapping(i):
+        charge_index = int(charge - 1)
+        m = matches[i]
+        if charge_index < len(m):
+            try:
+                s = ";".join(map(str, m[charge_index][attr]))
+            except:
+                raise ValueError(m[charge_index][attr])
+        else:
+            s = ""
+        return s
+
+    return mapping
+
+
+def augment(df, ion_types, charge_max):
+    matches = {}
+    for i, row in df.iterrows():
+        matches[i] = match(row, ion_types, charge_max)
+
+    # augment dataframe and write
+    for charge in range(1, charge_max + 1):
+        df["matches_charge{}".format(charge)] = df.index.map(
+            c_lambda(matches, charge, "matches")
+        )
+        df["masses_the_charge{}".format(charge)] = df.index.map(
+            c_lambda(matches, charge, "masses_theoretical")
+        )
+        df["masses_raw_charge{}".format(charge)] = df.index.map(
+            c_lambda(matches, charge, "masses_raw")
+        )
+        df["intensities_raw_charge{}".format(charge)] = df.index.map(
+            c_lambda(matches, charge, "intensities_raw")
+        )
+
+    return df

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -1,0 +1,114 @@
+# Code from (or adapted from) https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+import numpy
+import functools
+from .constants import *
+#import losses
+
+def reshape_dims(array):
+    n, dims = array.shape
+    assert dims == 174
+    nlosses = 1
+#    print(array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), nlosses, MAX_FRAG_CHARGE)
+    return array.reshape(
+        [array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), nlosses, MAX_FRAG_CHARGE]
+    )
+
+
+def reshape_flat(array):
+    s = array.shape
+    flat_dim = [s[0], functools.reduce(lambda x, y: x * y, s[1:], 1)]
+    return array.reshape(flat_dim)
+
+
+def normalize_base_peak(array):
+    # flat
+    maxima = array.max(axis=1)
+    array = array / maxima[:, numpy.newaxis]
+    return array
+
+
+def mask_outofrange(array, lengths, mask=-1.0):
+    # dim
+    for i in range(array.shape[0]):
+        array[i, lengths[i] - 1 :, :, :, :] = mask
+    return array
+
+
+def cap(array, nlosses=1, z=3):
+    return array[:, :, :, :nlosses, :z]
+
+
+def mask_outofcharge(array, charges, mask=-1.0):
+    # dim
+    for i in range(array.shape[0]):
+        if charges[i] < 3:
+            array[i, :, :, :, charges[i] :] = mask
+    return array
+
+
+def get_spectral_angle(true, pred, batch_size=600):
+    import tensorflow.compat.v1 as tfold
+
+    n = true.shape[0]
+    sa = numpy.zeros([n])
+
+    def iterate():
+        if n > batch_size:
+            for i in range(n // batch_size):
+                true_sample = true[i * batch_size : (i + 1) * batch_size]
+                pred_sample = pred[i * batch_size : (i + 1) * batch_size]
+                yield i, true_sample, pred_sample
+            i = n // batch_size
+            yield i, true[(i) * batch_size :], pred[(i) * batch_size :]
+        else:
+            yield 0, true, pred
+
+    for i, t_b, p_b in iterate():
+        tfold.compat.v1.reset_default_graph()
+        with tfold.Session() as s:
+            sa_graph = losses.masked_spectral_distance(t_b, p_b)
+            sa_b = 1 - s.run(sa_graph)
+            sa[i * batch_size : i * batch_size + sa_b.shape[0]] = sa_b
+    sa = numpy.nan_to_num(sa)
+    return sa
+
+
+def prediction(data, batch_size=600):
+    assert "sequence_integer" in data
+    assert "intensities_pred" in data
+    assert "precursor_charge_onehot" in data
+
+    sequence_lengths = numpy.count_nonzero(data["sequence_integer"], axis=1)
+    intensities = data["intensities_pred"]
+    charges = list(data["precursor_charge_onehot"].argmax(axis=1) + 1)
+
+#    print("charges", list(charges))
+
+    intensities[intensities < 0] = 0
+
+#    print('zeroing', list(intensities))
+
+    intensities = normalize_base_peak(intensities)
+#    print('normalize_base_peak', intensities)
+
+    intensities = reshape_dims(intensities)
+#    print('reshape_dims', intensities)
+
+    intensities = mask_outofrange(intensities, sequence_lengths)
+#    print('mask_outofrange', intensities)
+
+    intensities = mask_outofcharge(intensities, charges)
+#    print('mask_outofcharge', intensities)
+
+    intensities = reshape_flat(intensities)
+#    print('reshape_flat', intensities)
+
+    data["intensities_pred"] = intensities
+
+    if "intensities_raw" in data:
+        data["spectral_angle"] = get_spectral_angle(
+            data["intensities_raw"], data["intensities_pred"], batch_size=batch_size
+        )
+    return data

--- a/aiproteomics/e2e/speclibgen.py
+++ b/aiproteomics/e2e/speclibgen.py
@@ -1,0 +1,62 @@
+from . import sanitize
+import pandas as pd
+import numpy as np
+from aiproteomics.e2e import convert_to_msp
+from . import tensorize
+
+def _predict(data, model_frag, model_irt, batch_size_frag=None, batch_size_iRT=None, iRT_rescaling_mean=None, iRT_rescaling_var=None):
+    # Get fragmentation model predictions
+    x = [data['sequence_integer'], data['precursor_charge_onehot'], data['collision_energy_aligned_normed']]
+    prediction = model_frag.predict(x, verbose=False, batch_size=batch_size_frag)
+    data["intensities_pred"] = prediction
+    data = sanitize.prediction(data)
+
+    # Get iRT model predictions
+    x = data['sequence_integer']
+    prediction = model_irt.predict(x, verbose=False, batch_size=batch_size_iRT)
+    data["iRT"] = prediction * np.sqrt(iRT_rescaling_var) + iRT_rescaling_mean
+
+    return data
+
+
+def _read_peptides_csv(fname):
+
+    df = pd.read_csv(fname)    
+    df.reset_index(drop=True, inplace=True)
+    assert "modified_sequence" in df.columns
+    assert "collision_energy" in df.columns
+    assert "precursor_charge" in df.columns
+    data = {
+        "collision_energy_aligned_normed": tensorize.get_numbers(df.collision_energy) / 100.0,
+        "sequence_integer": tensorize.get_sequence_integer(df.modified_sequence),
+        "precursor_charge_onehot": tensorize.get_precursor_charge_onehot(df.precursor_charge),
+        "masses_pred": tensorize.get_mz_applied(df),
+    }
+    nlosses = 1
+    z = 3
+    lengths = (data["sequence_integer"] > 0).sum(1)
+
+    masses_pred = tensorize.get_mz_applied(df)
+    masses_pred = sanitize.cap(masses_pred, nlosses, z)
+    masses_pred = sanitize.mask_outofrange(masses_pred, lengths)
+    masses_pred = sanitize.mask_outofcharge(masses_pred, df.precursor_charge)
+    masses_pred = sanitize.reshape_flat(masses_pred)
+    data["masses_pred"] = masses_pred
+
+    return data
+
+
+def csv_to_msp(in_csv_fname, out_msp_fname, model_frag, model_irt, batch_size_frag, batch_size_iRT, iRT_rescaling_mean, iRT_rescaling_var):
+    data = _read_peptides_csv(in_csv_fname)
+    data = _predict(data,
+               model_frag,
+               model_irt,
+               batch_size_frag=batch_size_frag,
+               batch_size_iRT=batch_size_iRT,
+               iRT_rescaling_mean = iRT_rescaling_mean,
+               iRT_rescaling_var = iRT_rescaling_var
+              )
+
+    c = convert_to_msp.Converter(data, out_msp_fname)
+    c.convert()
+

--- a/aiproteomics/e2e/tensorize.py
+++ b/aiproteomics/e2e/tensorize.py
@@ -1,0 +1,109 @@
+import collections
+import numpy as np
+
+from . import constants
+from . import utils
+from . import match
+from . import annotate
+from . import sanitize
+from .constants import (
+    CHARGES,
+    MAX_SEQUENCE,
+    ALPHABET,
+    MAX_ION,
+    NLOSSES,
+    CHARGES,
+    ION_TYPES,
+    ION_OFFSET,
+)
+
+
+def stack(queue):
+    listed = collections.defaultdict(list)
+    for t in queue.values():
+        if t is not None:
+            for k, d in t.items():
+                listed[k].append(d)
+    stacked = {}
+    for k, d in listed.items():
+        if isinstance(d[0], list):
+            stacked[k] = [item for sublist in d for item in sublist]
+        else:
+            stacked[k] = np.vstack(d)
+    return stacked
+
+
+def get_numbers(vals, dtype=float):
+    a = np.array(vals).astype(dtype)
+    return a.reshape([len(vals), 1])
+
+
+def get_precursor_charge_onehot(charges):
+    array = np.zeros([len(charges), max(CHARGES)], dtype=int)
+    for i, precursor_charge in enumerate(charges):
+        array[i, precursor_charge - 1] = 1
+    return array
+
+
+def get_sequence_integer(sequences):
+    array = np.zeros([len(sequences), MAX_SEQUENCE], dtype=int)
+    for i, sequence in enumerate(sequences):
+        for j, s in enumerate(utils.peptide_parser(sequence)):
+            array[i, j] = ALPHABET[s]
+    return array
+
+
+def parse_ion(string):
+    ion_type = ION_TYPES.index(string[0])
+    if ("-") in string:
+        ion_n, suffix = string[1:].split("-")
+    else:
+        ion_n = string[1:]
+        suffix = ""
+    return ion_type, int(ion_n) - 1, NLOSSES.index(suffix)
+
+
+def get_mz_applied(df, ion_types="yb"):
+    ito = {it: ION_OFFSET[it] for it in ion_types}
+
+    def calc_row(row):
+        array = np.zeros([MAX_ION, len(ION_TYPES), len(NLOSSES), len(CHARGES)])
+        fw, bw = match.get_forward_backward(row.modified_sequence)
+        for z in range(row.precursor_charge):
+            zpp = z + 1
+            annotation = annotate.get_annotation(fw, bw, zpp, ito)
+            for ion, mz in annotation.items():
+                it, _in, nloss = parse_ion(ion)
+                array[_in, it, nloss, z] = mz
+        return [array]
+
+    mzs_series = df.apply(calc_row, 1)
+    out = np.squeeze(np.stack(mzs_series))
+    if len(out.shape) == 4:
+        out = out.reshape([1] + list(out.shape))
+    return out
+
+
+def csv(df):
+    df.reset_index(drop=True, inplace=True)
+    assert "modified_sequence" in df.columns
+    assert "collision_energy" in df.columns
+    assert "precursor_charge" in df.columns
+    data = {
+        "collision_energy_aligned_normed": get_numbers(df.collision_energy) / 100.0,
+        "sequence_integer": get_sequence_integer(df.modified_sequence),
+        "precursor_charge_onehot": get_precursor_charge_onehot(df.precursor_charge),
+        "masses_pred": get_mz_applied(df),
+    }
+    nlosses = 1
+    z = 3
+    lengths = (data["sequence_integer"] > 0).sum(1)
+
+    masses_pred = get_mz_applied(df)
+    masses_pred = sanitize.cap(masses_pred, nlosses, z)
+    masses_pred = sanitize.mask_outofrange(masses_pred, lengths)
+    masses_pred = sanitize.mask_outofcharge(masses_pred, df.precursor_charge)
+    masses_pred = sanitize.reshape_flat(masses_pred)
+    data["masses_pred"] = masses_pred
+
+    return data

--- a/aiproteomics/e2e/utils.py
+++ b/aiproteomics/e2e/utils.py
@@ -1,0 +1,43 @@
+# Code from (or adapted from) https://github.com/kusterlab/prosit/ Apache License 2.0
+# See README.md
+
+
+from aiproteomics.e2e.constants import MAX_ION, ION_TYPES, ALPHABET_S
+
+
+def check_mandatory_keys(dictionary, keys):
+    for key in keys:
+        if key not in dictionary.keys():
+            raise KeyError("key {} is missing".format(key))
+    return True
+
+
+def reshape_dims(array, nlosses=1, z=3):
+    return array.reshape([array.shape[0], MAX_ION, len(ION_TYPES), nlosses, z])
+
+
+def get_sequence(sequence):
+    d = ALPHABET_S
+    return "".join([d[i] if i in d else "" for i in sequence])
+
+
+def sequence_integer_to_str(array):
+    sequences = [get_sequence(array[i]) for i in range(array.shape[0])]
+    return sequences
+
+
+def peptide_parser(p):
+    p = p.replace("_", "")
+    if p[0] == "(":
+        raise ValueError("sequence starts with '('")
+    n = len(p)
+    i = 0
+    while i < n:
+        if i < n - 3 and p[i + 1] == "(":
+            j = p[i + 2 :].index(")")
+            offset = i + j + 3
+            yield p[i:offset]
+            i = offset
+        else:
+            yield p[i]
+            i += 1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 # requirements
 
-tensorflow==2.6.0
-keras==2.6.0
+tensorflow==2.11.0
+keras==2.11.0
 tf2onnx
+pandas==1.5.2


### PR DESCRIPTION
Adds an adapted form of the msp writer from the prosit code base. This is available in the `e2e` module. There is a demo notebook (demo/demo_e2e.ipynb) showing how it works.

You can convert a csv list of peptides to an msp spectral library file using `aiproteomics.e2e.speclibgen.csv_to_msp()`