### PR TITLE
Add comments and tidy up code for end to end pipeline

### DIFF
--- a/aiproteomics/e2e/constants.py
+++ b/aiproteomics/e2e/constants.py
@@ -33,6 +33,7 @@ MAX_SEQUENCE = 30
 MAX_ION = MAX_SEQUENCE - 1
 ION_TYPES = ["y", "b"]
 NLOSSES = ["", "H2O", "NH3"]
+MAX_NLOSSES = 1
 
 FORWARD = {"a", "b", "c"}
 BACKWARD = {"x", "y", "z"}

--- a/aiproteomics/e2e/convert_to_msp.py
+++ b/aiproteomics/e2e/convert_to_msp.py
@@ -122,7 +122,7 @@ class Converter():
                 sel = np.where(aIntensity > 0)
                 aIntensity = aIntensity[sel]
                 collision_energy = self.data["collision_energy_aligned_normed"][i] * 100
-                iRT = self.data["iRT"][i]
+                iRT = np.squeeze(self.data["iRT"][i])
                 aMass = self.data["masses_pred"][i][sel]
                 precursor_charge = self.data["precursor_charge_onehot"][i].argmax() + 1
                 sequence_integer = self.data["sequence_integer"][i]
@@ -173,7 +173,8 @@ class Spectrum(object):
     def __str__(self):
         s = "Name: {sequence}/{charge}\nMW: {precursor_mass}\n"
         s += "Comment: Parent={precursor_mass} Collision_energy={collision_energy} "
-        s += "Mods={mod} ModString={sequence}//{mod_string}/{charge}"
+        s += "Mods={mod} ModString={sequence}//{mod_string}/{charge} "
+        s += "iRT={iRT}"
         s += "\nNum peaks: {num_peaks}"
         num_peaks = len(self.aIntensity)
         s = s.format(
@@ -183,6 +184,7 @@ class Spectrum(object):
             collision_energy=np.round(self.collision_energy[0], 0),
             mod=self.mod,
             mod_string=self.mod_string,
+            iRT=self.iRT,
             num_peaks=num_peaks,
         )
         for mz, intensity, ion in zip(self.aMass, self.aIntensity, self.aIons):

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -81,8 +81,4 @@ def prediction(data, batch_size=600):
 
     data["intensities_pred"] = intensities
 
-    if "intensities_raw" in data:
-        data["spectral_angle"] = get_spectral_angle(
-            data["intensities_raw"], data["intensities_pred"], batch_size=batch_size
-        )
     return data

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -47,7 +47,7 @@ def mask_outofcharge(array, charges, mask=-1.0):
     return array
 
 
-def prediction(data, batch_size=600):
+def sanitize_prediction_output(data, batch_size=600):
     """
     Default prosit output layer is 174, coming from a
     flattening of array with dimensions: 29 x 2 x 1 x 3

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -6,6 +6,12 @@ import functools
 from .constants import *
 
 def reshape_dims(array):
+    """
+    "Deflatten" the intensities array (from the size 174 prosit output layer)
+    to the form N_sequences x MAX_SEQUENCE - 1 x len(ION_TYPES) x nlosses x MAX_FRAG_CHARGE
+    For default output layer size 174, this corresponds to the shape:
+    N_sequences x 29 x 2 x 1 x 3
+    """
     n, dims = array.shape
     assert dims == 174
     nlosses = 1
@@ -16,31 +22,55 @@ def reshape_dims(array):
 
 
 def reshape_flat(array):
+    """
+    Reshape the given array to shape (N_sequences x flat_array_length)
+    where N_sequences is the length of the first axis,
+    and flat_array_length is the combined flattened length of all remaining axes.
+    For standard prosit defaults, this results in a shape of N_sequences x 174.
+    """
+
     s = array.shape
     flat_dim = [s[0], functools.reduce(lambda x, y: x * y, s[1:], 1)]
     return array.reshape(flat_dim)
 
 
 def normalize_base_peak(array):
-    # flat
+    """
+    Normalize by the highest intensity peak within each sequence
+    """
     maxima = array.max(axis=1)
     array = array / maxima[:, numpy.newaxis]
     return array
 
 
 def mask_outofrange(array, lengths, mask=-1.0):
-    # dim
+    """
+    Sets all values to mask for entries beyond the peptide sequence length.
+    The max length is 29 (for a peptide length of 30 amino acids) but many
+    sequences will be shorter, and so the unused remainder of the array is masked.
+    """
     for i in range(array.shape[0]):
         array[i, lengths[i] - 1 :, :, :, :] = mask
     return array
 
 
 def cap(array, nlosses=1, z=3):
+    """
+    Caps the neutral losses and frag charges to nlosses and z, respectively.
+
+    Caps the shape to (:, :, :, nlosses, z)
+    For example, if nlosses=1 and z=3, then
+    an array of shape (3, 29, 2, 3, 6) -> (3, 29, 2, 1, 3)
+    """
+
     return array[:, :, :, :nlosses, :z]
 
 
 def mask_outofcharge(array, charges, mask=-1.0):
-    # dim
+    """
+    For each quence, mask any entries corresponding to charges
+    greater than the threshold provided in 'charges'.
+    """
     for i in range(array.shape[0]):
         if charges[i] < 3:
             array[i, :, :, :, charges[i] :] = mask

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -4,7 +4,6 @@
 import numpy
 import functools
 from .constants import *
-#import losses
 
 def reshape_dims(array):
     n, dims = array.shape
@@ -46,33 +45,6 @@ def mask_outofcharge(array, charges, mask=-1.0):
         if charges[i] < 3:
             array[i, :, :, :, charges[i] :] = mask
     return array
-
-
-def get_spectral_angle(true, pred, batch_size=600):
-    import tensorflow.compat.v1 as tfold
-
-    n = true.shape[0]
-    sa = numpy.zeros([n])
-
-    def iterate():
-        if n > batch_size:
-            for i in range(n // batch_size):
-                true_sample = true[i * batch_size : (i + 1) * batch_size]
-                pred_sample = pred[i * batch_size : (i + 1) * batch_size]
-                yield i, true_sample, pred_sample
-            i = n // batch_size
-            yield i, true[(i) * batch_size :], pred[(i) * batch_size :]
-        else:
-            yield 0, true, pred
-
-    for i, t_b, p_b in iterate():
-        tfold.compat.v1.reset_default_graph()
-        with tfold.Session() as s:
-            sa_graph = losses.masked_spectral_distance(t_b, p_b)
-            sa_b = 1 - s.run(sa_graph)
-            sa[i * batch_size : i * batch_size + sa_b.shape[0]] = sa_b
-    sa = numpy.nan_to_num(sa)
-    return sa
 
 
 def prediction(data, batch_size=600):

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -10,7 +10,7 @@ def reshape_dims(array):
     n, dims = array.shape
     assert dims == 174
     nlosses = 1
-#    print(array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), nlosses, MAX_FRAG_CHARGE)
+
     return array.reshape(
         [array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), nlosses, MAX_FRAG_CHARGE]
     )
@@ -84,26 +84,12 @@ def prediction(data, batch_size=600):
     intensities = data["intensities_pred"]
     charges = list(data["precursor_charge_onehot"].argmax(axis=1) + 1)
 
-#    print("charges", list(charges))
-
     intensities[intensities < 0] = 0
-
-#    print('zeroing', list(intensities))
-
     intensities = normalize_base_peak(intensities)
-#    print('normalize_base_peak', intensities)
-
     intensities = reshape_dims(intensities)
-#    print('reshape_dims', intensities)
-
     intensities = mask_outofrange(intensities, sequence_lengths)
-#    print('mask_outofrange', intensities)
-
     intensities = mask_outofcharge(intensities, charges)
-#    print('mask_outofcharge', intensities)
-
     intensities = reshape_flat(intensities)
-#    print('reshape_flat', intensities)
 
     data["intensities_pred"] = intensities
 

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -8,16 +8,15 @@ from .constants import *
 def reshape_dims(array):
     """
     "Deflatten" the intensities array (from the size 174 prosit output layer)
-    to the form N_sequences x MAX_SEQUENCE - 1 x len(ION_TYPES) x nlosses x MAX_FRAG_CHARGE
+    to the form N_sequences x MAX_SEQUENCE - 1 x len(ION_TYPES) x MAX_NLOSSES x MAX_FRAG_CHARGE
     For default output layer size 174, this corresponds to the shape:
     N_sequences x 29 x 2 x 1 x 3
     """
     n, dims = array.shape
     assert dims == 174
-    nlosses = 1
 
     return array.reshape(
-        [array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), nlosses, MAX_FRAG_CHARGE]
+        [array.shape[0], MAX_SEQUENCE - 1, len(ION_TYPES), MAX_NLOSSES, MAX_FRAG_CHARGE]
     )
 
 

--- a/aiproteomics/e2e/sanitize.py
+++ b/aiproteomics/e2e/sanitize.py
@@ -3,7 +3,7 @@
 
 import numpy
 import functools
-from .constants import *
+from aiproteomics.e2e.constants import *
 
 def reshape_dims(array):
     """

--- a/aiproteomics/e2e/speclibgen.py
+++ b/aiproteomics/e2e/speclibgen.py
@@ -30,10 +30,12 @@ def _read_peptides_csv(fname):
         "collision_energy_aligned_normed": tensorize.get_numbers(df.collision_energy) / 100.0,
         "sequence_integer": tensorize.get_sequence_integer(df.modified_sequence),
         "precursor_charge_onehot": tensorize.get_precursor_charge_onehot(df.precursor_charge),
-        "masses_pred": tensorize.get_mz_applied(df),
     }
+
     nlosses = 1
     z = 3
+
+    # Calculate length of each (integer) peptide sequence
     lengths = (data["sequence_integer"] > 0).sum(1)
 
     masses_pred = tensorize.get_mz_applied(df)

--- a/aiproteomics/e2e/speclibgen.py
+++ b/aiproteomics/e2e/speclibgen.py
@@ -1,8 +1,8 @@
 from . import sanitize
 import pandas as pd
 import numpy as np
-from aiproteomics.e2e import convert_to_msp
-from . import tensorize
+from aiproteomics.e2e import convert_to_msp, tensorize
+from aiproteomics.e2e.constants import MAX_FRAG_CHARGE, MAX_NLOSSES
 
 def _predict(data, model_frag, model_irt, batch_size_frag=None, batch_size_iRT=None, iRT_rescaling_mean=None, iRT_rescaling_var=None):
     # Get fragmentation model predictions

--- a/aiproteomics/e2e/speclibgen.py
+++ b/aiproteomics/e2e/speclibgen.py
@@ -32,9 +32,6 @@ def _read_peptides_csv(fname):
         "precursor_charge_onehot": tensorize.get_precursor_charge_onehot(df.precursor_charge),
     }
 
-    nlosses = 1 # Cap for neutral losses?
-    z = 3 # Cap for fragment charge
-
     # Calculate length of each (integer) peptide sequence
     lengths = (data["sequence_integer"] > 0).sum(1)
 
@@ -47,11 +44,7 @@ def _read_peptides_csv(fname):
     #               )
     masses_pred = tensorize.get_mz_applied(df)
 
-    # Caps the shape to (:, :, :, nlosses, z)
-    # For example, if nlosses=1 and z=3, then
-    # shape (3, 29, 2, 3, 6) -> (3, 29, 2, 1, 3)
-    masses_pred = sanitize.cap(masses_pred, nlosses, z)
-
+    masses_pred = sanitize.cap(masses_pred, MAX_NLOSSES, MAX_FRAG_CHARGE)
     masses_pred = sanitize.mask_outofrange(masses_pred, lengths)
     masses_pred = sanitize.mask_outofcharge(masses_pred, df.precursor_charge)
 
@@ -92,8 +85,8 @@ def csv_to_msp(in_csv_fname, out_msp_fname, model_frag, model_irt, batch_size_fr
                model_irt,
                batch_size_frag=batch_size_frag,
                batch_size_iRT=batch_size_iRT,
-               iRT_rescaling_mean = iRT_rescaling_mean,
-               iRT_rescaling_var = iRT_rescaling_var
+               iRT_rescaling_mean=iRT_rescaling_mean,
+               iRT_rescaling_var=iRT_rescaling_var
               )
 
     c = convert_to_msp.Converter(data, out_msp_fname)

--- a/aiproteomics/e2e/tensorize.py
+++ b/aiproteomics/e2e/tensorize.py
@@ -34,11 +34,30 @@ def stack(queue):
 
 
 def get_numbers(vals, dtype=float):
+    """
+    Takes input list and converts values to specified numpy dtype.
+    Outputs numpy array in "column format", i.e.
+        If input looks like:
+            [35, 30, 30],
+        Output looks like:
+            array([[35.],
+            [30.],
+            [30.]])
+    """
     a = np.array(vals).astype(dtype)
     return a.reshape([len(vals), 1])
 
 
 def get_precursor_charge_onehot(charges):
+    """
+    Input:
+        charges: int
+    Output:
+        onehot encoded array of length max(CHARGES)
+    Example:
+        If charges=3, and the max charge number is 6, then
+        the output will be [0, 0, 1, 0, 0, 0]
+    """
     array = np.zeros([len(charges), max(CHARGES)], dtype=int)
     for i, precursor_charge in enumerate(charges):
         array[i, precursor_charge - 1] = 1
@@ -46,6 +65,10 @@ def get_precursor_charge_onehot(charges):
 
 
 def get_sequence_integer(sequences):
+    """
+    Takes modified sequence (string) as input. For example, "MMPAAALIM(ox)R"
+    Maps it to an array of integers, according to the prosit alphabet.
+    """
     array = np.zeros([len(sequences), MAX_SEQUENCE], dtype=int)
     for i, sequence in enumerate(sequences):
         for j, s in enumerate(utils.peptide_parser(sequence)):
@@ -97,6 +120,8 @@ def csv(df):
     }
     nlosses = 1
     z = 3
+
+    # Calculate length of each (integer) peptide sequence
     lengths = (data["sequence_integer"] > 0).sum(1)
 
     masses_pred = get_mz_applied(df)

--- a/aiproteomics/e2e/tensorize.py
+++ b/aiproteomics/e2e/tensorize.py
@@ -115,8 +115,7 @@ def csv(df):
     data = {
         "collision_energy_aligned_normed": get_numbers(df.collision_energy) / 100.0,
         "sequence_integer": get_sequence_integer(df.modified_sequence),
-        "precursor_charge_onehot": get_precursor_charge_onehot(df.precursor_charge),
-        "masses_pred": get_mz_applied(df),
+        "precursor_charge_onehot": get_precursor_charge_onehot(df.precursor_charge)
     }
     nlosses = 1
     z = 3

--- a/aiproteomics/e2e/tensorize.py
+++ b/aiproteomics/e2e/tensorize.py
@@ -105,29 +105,3 @@ def get_mz_applied(df, ion_types="yb"):
     if len(out.shape) == 4:
         out = out.reshape([1] + list(out.shape))
     return out
-
-
-def csv(df):
-    df.reset_index(drop=True, inplace=True)
-    assert "modified_sequence" in df.columns
-    assert "collision_energy" in df.columns
-    assert "precursor_charge" in df.columns
-    data = {
-        "collision_energy_aligned_normed": get_numbers(df.collision_energy) / 100.0,
-        "sequence_integer": get_sequence_integer(df.modified_sequence),
-        "precursor_charge_onehot": get_precursor_charge_onehot(df.precursor_charge)
-    }
-    nlosses = 1
-    z = 3
-
-    # Calculate length of each (integer) peptide sequence
-    lengths = (data["sequence_integer"] > 0).sum(1)
-
-    masses_pred = get_mz_applied(df)
-    masses_pred = sanitize.cap(masses_pred, nlosses, z)
-    masses_pred = sanitize.mask_outofrange(masses_pred, lengths)
-    masses_pred = sanitize.mask_outofcharge(masses_pred, df.precursor_charge)
-    masses_pred = sanitize.reshape_flat(masses_pred)
-    data["masses_pred"] = masses_pred
-
-    return data


### PR DESCRIPTION
Big tidy up of the adapted prosit code. Added comments/docstrings for majority of functions used for spectral lib generation. Removed duplicate functions etc. Sanitized the use of constants (there was a lot of hardcoding of vars floating around in the original code). Should now be a lot easier to generalize to a different model.