### PR TITLE
Remove unused config file

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,7 +1,0 @@
-version: 2
-python:
-  install:
-    - method: pip
-      path: .
-      extra_requirements:
-        - dev


### PR DESCRIPTION
We use mkdocs now, so no need for readthedocs config.