### PR TITLE
Fix bug in m/z calculation not using charge when subtracting neutral losses

### DIFF
--- a/aiproteomics/core/mz.py
+++ b/aiproteomics/core/mz.py
@@ -66,7 +66,14 @@ def get_ion_mz(seq, frag: Fragment, aa_mass):
     else:
         frag_seq = seq[-ion_break:]
 
-    return mass.fast_mass(frag_seq, ion_type=ion_type, charge=ion_charge, aa_mass=aa_mass)
+    # Calculate the m/z for the sequence fragment (ignoring neutral losses)
+    mz = mass.fast_mass(frag_seq, ion_type=ion_type, charge=ion_charge, aa_mass=aa_mass)
+
+    # If there is a neutral loss, subtract it from the m/z
+    if frag.fragment_loss_type:
+        mz -= mass_neutral_loss[frag.fragment_loss_type]/ion_charge
+
+    return mz
 
 
 def get_precursor_mz(seq, charge, aa_mass):

--- a/tools/psm2speclib.py
+++ b/tools/psm2speclib.py
@@ -69,9 +69,6 @@ def parse_ions(str_matches, str_intensities, seq):
         else:
             ion_mz = get_ion_mz(seq, frag, aa_mass)
 
-        if frag.fragment_loss_type:
-            ion_mz -= mass_neutral_loss[frag.fragment_loss_type]
-
         annotations.append(annotation)
         intensities.append(float(intensity))
         ion_mzs.append(ion_mz)

--- a/tools/psm2speclib.py
+++ b/tools/psm2speclib.py
@@ -5,7 +5,7 @@ import dask.dataframe as dd
 from dask.diagnostics import ProgressBar
 
 from aiproteomics.core.definitions import ANNOTATION_pY
-from aiproteomics.core.mz import MASS_pY, get_ion_mz, get_precursor_mz, aa_mass, mass_neutral_loss
+from aiproteomics.core.mz import MASS_pY, get_ion_mz, get_precursor_mz, aa_mass
 from aiproteomics.core.sequence import SequenceMapper, PHOSPHO_MAPPING
 from aiproteomics.core.utils import parse_ion_annotation
 


### PR DESCRIPTION
Fixes a bug found by Alex. Now all the m/z calculation takes place inside `get_ion_mz()`